### PR TITLE
修复默认的进场和出场动画的bug

### DIFF
--- a/DialogX/src/main/res/anim/anim_dialogx_default_enter.xml
+++ b/DialogX/src/main/res/anim/anim_dialogx_default_enter.xml
@@ -12,6 +12,6 @@
 
     <alpha
         android:duration="300"
-        android:fromAlpha="1.0"
+        android:fromAlpha="0.0"
         android:toAlpha="1.0" />
 </set>

--- a/DialogX/src/main/res/anim/anim_dialogx_default_exit.xml
+++ b/DialogX/src/main/res/anim/anim_dialogx_default_exit.xml
@@ -4,6 +4,6 @@
     <alpha
         android:duration="300"
         android:fromAlpha="1.0"
-        android:toAlpha="1.0" />
+        android:toAlpha="0.0" />
 
 </set>


### PR DESCRIPTION
现在进场出场都是alpha=1.0，导致动画很突兀