### PR TITLE
BottomMenu支持菜单项对齐方式设置（如居中）

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/BottomMenu.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/BottomMenu.java
@@ -1,5 +1,6 @@
 package com.kongzue.dialogx.dialogs;
 
+import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -51,7 +52,7 @@ public class BottomMenu extends BottomDialog {
     protected int selectionIndex = -1;
     protected SELECT_MODE selectMode = SELECT_MODE.NONE;
     protected ArrayList<Integer> selectionItems;
-    
+
     protected OnMenuItemClickListener<BottomMenu> onMenuItemClickListener;
     
     public static BottomMenu build() {
@@ -77,6 +78,7 @@ public class BottomMenu extends BottomDialog {
     private BottomDialogListView listView;
     private BaseAdapter menuListAdapter;
     private List<CharSequence> menuList;
+    private int menuItemGravity = Gravity.CENTER_VERTICAL;
     
     public static BottomMenu show(List<CharSequence> menuList) {
         BottomMenu bottomMenu = new BottomMenu();
@@ -1115,6 +1117,15 @@ public class BottomMenu extends BottomDialog {
     
     public BottomMenu setMenuItemTextInfoInterceptor(MenuItemTextInfoInterceptor<BottomMenu> menuItemTextInfoInterceptor) {
         this.menuItemTextInfoInterceptor = menuItemTextInfoInterceptor;
+        return this;
+    }
+
+    public int getMenuItemGravity(){
+        return this.menuItemGravity;
+    }
+
+    public BottomMenu setMenuItemGravity(int gravity){
+        this.menuItemGravity = gravity;
         return this;
     }
 }

--- a/DialogX/src/main/java/com/kongzue/dialogx/util/BottomMenuArrayAdapter.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/util/BottomMenuArrayAdapter.java
@@ -17,6 +17,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.SimpleAdapter;
 import android.widget.Space;
 import android.widget.TextView;
@@ -51,6 +52,7 @@ public class BottomMenuArrayAdapter extends BaseAdapter {
         ImageView imgDialogxMenuSelection;
         TextView txtDialogxMenuText;
         Space spaceDialogxRightPadding;
+        LinearLayout menuItemLayout;
     }
     
     @Override
@@ -97,6 +99,7 @@ public class BottomMenuArrayAdapter extends BaseAdapter {
             viewHolder.imgDialogxMenuSelection = convertView.findViewById(R.id.img_dialogx_menu_selection);
             viewHolder.txtDialogxMenuText = convertView.findViewById(R.id.txt_dialogx_menu_text);
             viewHolder.spaceDialogxRightPadding = convertView.findViewById(R.id.space_dialogx_right_padding);
+            viewHolder.menuItemLayout = convertView.findViewById(R.id.layout_dialogx_menu_item);
             
             convertView.setTag(viewHolder);
         } else {
@@ -228,7 +231,8 @@ public class BottomMenuArrayAdapter extends BaseAdapter {
                 }
             }
         }
-        
+        viewHolder.menuItemLayout.setGravity(bottomMenu.getMenuItemGravity());
+
         return convertView;
     }
     

--- a/DialogX/src/main/res/layout/item_dialogx_material_bottom_menu_normal_text.xml
+++ b/DialogX/src/main/res/layout/item_dialogx_material_bottom_menu_normal_text.xml
@@ -3,6 +3,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
+        android:id="@+id/layout_dialogx_menu_item"
         android:layout_width="match_parent"
         android:layout_height="55dp"
         android:gravity="center_vertical"
@@ -29,9 +30,8 @@
 
         <TextView
             android:id="@+id/txt_dialogx_menu_text"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:gravity="left|center_vertical"
             android:maxLines="1"
             android:text=""


### PR DESCRIPTION
当使用普通菜单项（存文本）时，内容默认左对其不够美观