### PR TITLE
使用.getLocationInWindow替换.getLocationOnScreen以解决Demo中 选项菜单 这个功能在win11安…

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/GuideDialog.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/GuideDialog.java
@@ -430,7 +430,7 @@ public class GuideDialog extends CustomDialog {
         this.baseView(baseView);
         this.alignViewGravity = alignGravity;
         baseViewLoc = new int[4];
-        baseView.getLocationOnScreen(baseViewLoc);
+        baseView.getLocationInWindow(baseViewLoc);
         setFullScreen(true);
         return this;
     }
@@ -438,7 +438,7 @@ public class GuideDialog extends CustomDialog {
     public GuideDialog setAlignBaseViewGravity(View baseView) {
         this.baseView(baseView);
         baseViewLoc = new int[4];
-        baseView.getLocationOnScreen(baseViewLoc);
+        baseView.getLocationInWindow(baseViewLoc);
         setFullScreen(true);
         return this;
     }
@@ -447,7 +447,7 @@ public class GuideDialog extends CustomDialog {
         this.alignViewGravity = alignGravity;
         if (baseView() != null) {
             baseViewLoc = new int[4];
-            baseView().getLocationOnScreen(baseViewLoc);
+            baseView().getLocationInWindow(baseViewLoc);
         }
         setFullScreen(true);
         return this;

--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
@@ -249,7 +249,7 @@ public class PopMenu extends BaseDialog {
                 public void onDraw() {
                     int[] baseViewLocCache = new int[2];
                     if (baseView() != null) {
-                        baseView().getLocationOnScreen(baseViewLocCache);
+                        baseView().getLocationInWindow(baseViewLocCache);
                         if (getDialogImpl() != null && !baseViewLoc.isSameLoc(baseViewLocCache)) {
                             baseViewLoc.set(baseViewLocCache);
                             refreshMenuLoc();
@@ -701,7 +701,7 @@ public class PopMenu extends BaseDialog {
                                     int[] viewLoc = new int[2];
                                     if (listMenu.getChildAt(selectMenuIndex) != null) {
                                         int itemHeight = listMenu.getChildAt(selectMenuIndex).getMeasuredHeight();
-                                        listMenu.getChildAt(selectMenuIndex).getLocationOnScreen(viewLoc);
+                                        listMenu.getChildAt(selectMenuIndex).getLocationInWindow(viewLoc);
                                         selectItemYDeviation = (int) ((baseView().getMeasuredHeight() / 2f) - (viewLoc[1] - boxBody.getY()) - (itemHeight / 2f));
                                     }
                                 }


### PR DESCRIPTION
PopupMenu也存在这个问题，替换了后一切看起来是正常的；