### PR TITLE
修复在低于api 30的手机上，系统栏隐藏了，但获取到的insets依然有系统栏可见时的系统栏高度问题.

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/util/views/FitSystemBarUtils.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/util/views/FitSystemBarUtils.java
@@ -198,35 +198,43 @@ public class FitSystemBarUtils {
         int cutoutPaddingRight = 0;
         int cutoutPaddingBottom = 0;
 
-        int systemWindowInsetLeft;
-        int systemWindowInsetTop;
-        int systemWindowInsetRight;
-        int systemWindowInsetBottom;
+        int systemWindowInsetLeft = 0;
+        int systemWindowInsetTop = 0;
+        int systemWindowInsetRight = 0;
+        int systemWindowInsetBottom = 0;
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-            if (safeCutOutPadding) {
-                DisplayCutoutCompat displayCutout = insetsCompat.getDisplayCutout();
-                if (null != displayCutout) {
-                    cutoutPaddingTop = displayCutout.getSafeInsetTop();
-                    cutoutPaddingLeft = displayCutout.getSafeInsetLeft();
-                    cutoutPaddingRight = displayCutout.getSafeInsetRight();
-                    cutoutPaddingBottom = displayCutout.getSafeInsetRight();
-                }
+        if (safeCutOutPadding) {
+            DisplayCutoutCompat displayCutout = insetsCompat.getDisplayCutout();
+            if (null != displayCutout) {
+                cutoutPaddingTop = displayCutout.getSafeInsetTop();
+                cutoutPaddingLeft = displayCutout.getSafeInsetLeft();
+                cutoutPaddingRight = displayCutout.getSafeInsetRight();
+                cutoutPaddingBottom = displayCutout.getSafeInsetRight();
             }
         }
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
-            Insets systemBars = insetsCompat.getInsets(WindowInsetsCompat.Type.systemBars());
-            Insets ime = insetsCompat.getInsets(WindowInsetsCompat.Type.ime());
-            Insets maxInsets = androidx.core.graphics.Insets.max(ime, systemBars);
-            systemWindowInsetLeft = systemBars.left;
-            systemWindowInsetRight = systemBars.right;
+        Insets systemBars = insetsCompat.getInsets(
+                WindowInsetsCompat.Type.ime() | WindowInsetsCompat.Type.systemBars()
+        );
+        systemWindowInsetLeft = systemBars.left;
+        systemWindowInsetRight = systemBars.right;
+
+        //对api低于30的设备，做额外判断，api 30+的不需要这个
+        int suv = contentView.getRootView().getWindowSystemUiVisibility();
+        boolean statusBar = true;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            statusBar = (suv & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0;
+        }
+        boolean naviBar = true;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            naviBar = (suv & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+        }
+        if (naviBar && (insetsCompat.isVisible(WindowInsetsCompat.Type.ime())
+                        || insetsCompat.isVisible(WindowInsetsCompat.Type.navigationBars()))
+        ) {
+            systemWindowInsetBottom = systemBars.bottom;
+        }
+        if (statusBar && insetsCompat.isVisible(WindowInsetsCompat.Type.statusBars())) {
             systemWindowInsetTop = systemBars.top;
-            systemWindowInsetBottom = maxInsets.bottom;
-        } else {
-            systemWindowInsetLeft = insetsCompat.getSystemWindowInsetLeft();
-            systemWindowInsetRight = insetsCompat.getSystemWindowInsetRight();
-            systemWindowInsetTop = insetsCompat.getSystemWindowInsetTop();
-            systemWindowInsetBottom = insetsCompat.getSystemWindowInsetBottom();
         }
 
         if (callBack.isEnable(Orientation.Top)) {

--- a/app/src/main/java/com/kongzue/dialogxdemo/activity/MainActivity.java
+++ b/app/src/main/java/com/kongzue/dialogxdemo/activity/MainActivity.java
@@ -1,7 +1,5 @@
 package com.kongzue.dialogxdemo.activity;
 
-import static com.kongzue.dialogx.dialogs.PopTip.tip;
-
 import android.animation.ValueAnimator;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
@@ -1283,7 +1281,7 @@ public class MainActivity extends BaseActivity {
                                 dataArrayList.add(new CustomRecycleViewAdapter.Data("Item Text 12"));
                                 dataArrayList.add(new CustomRecycleViewAdapter.Data("Item Text 13"));
                                 dataArrayList.add(new CustomRecycleViewAdapter.Data("Item Text 14"));
-                                RecyclerView recyclerView = (RecyclerView) v;
+                                RecyclerView recyclerView = (RecyclerView) ((ViewGroup) v).getChildAt(0);
                                 LinearLayoutManager layoutManager = new LinearLayoutManager(me);
                                 recyclerView.setLayoutManager(layoutManager);
                                 CustomRecycleViewAdapter adapter = new CustomRecycleViewAdapter(dataArrayList);


### PR DESCRIPTION
对FitSystemBarUtils这个类做了点修改，之前的写法，在低于android11的系统上，当系统栏（状态栏和虚拟导航栏）被隐藏的时候，insets中依然能获取到系统栏的高度，而不是0，导致被设置了一个不应该有的padding。
