### PR TITLE
尝试修复 #370 bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,10 @@
             android:theme="@style/AppCompatTheme"
             android:windowSoftInputMode="adjustResize" />
 
+<!--            android:name=".activity.MainActivity"-->
+<!--            android:name=".activity.TestMainActivity"-->
         <activity
-            android:name=".activity.MainActivity"
+            android:name=".activity.TestMainActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|uiMode|screenLayout|smallestScreenSize|layoutDirection"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
 <!--            android:name=".activity.MainActivity"-->
 <!--            android:name=".activity.TestMainActivity"-->
+
         <activity
             android:name=".activity.TestMainActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|uiMode|screenLayout|smallestScreenSize|layoutDirection"

--- a/app/src/main/java/com/kongzue/dialogxdemo/activity/TestMainActivity.java
+++ b/app/src/main/java/com/kongzue/dialogxdemo/activity/TestMainActivity.java
@@ -1,0 +1,32 @@
+package com.kongzue.dialogxdemo.activity;
+
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.kongzue.dialogx.dialogs.BottomDialog;
+import com.kongzue.dialogxdemo.R;
+
+public class TestMainActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main_test);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().setStatusBarColor(ContextCompat.getColor(this,R.color.colorAccent));
+        }
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        findViewById(R.id.btn_showDialog).setOnClickListener(view -> {
+            BottomDialog.show("标题", "这里是对话框内容。")
+                    .setCancelButton("取消", (dialog, v) -> false)
+                    .setOkButton("确定", (dialog, v) -> false);
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_main_test.xml
+++ b/app/src/main/res/layout/activity_main_test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#3A3A3A">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="顶部文本"
+        android:textColor="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="底部文本"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/btn_showDialog"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Show Dialog!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
我排查了下，问题应该是没有启用沉浸式导致的。
但是因为无法判断是否开启了沉浸式，所以这个问题我也不知道如何优雅点解决。
Window类中有一个方法名叫：decorFitsSystemWindows，可以通过这个判断，是否开启了沉浸式
但是被标记为hide了，无法调用（尝试通过反射获取，也失败了），目前我暂未找到拿到这个值的办法；
目前已知在android 14上，如果这个未被设置为false的话，windowInsets中的bottom会为0，暂未测试低于14的版本，猜测11及以上都会这样。
所以我想了个办法尝试解决这个问题，但不知道会不会有其它影响。

请注意：
demo的启动页 被我修改成了新添加的activity，以验证修改是否有效！