### PR TITLE
为 PopNotification 添加震动，修复 PopMenu 在连续弹窗中，部分情况下弹窗不会响应关闭的问题。

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
@@ -95,8 +95,6 @@ public class PopMenu extends BaseDialog {
     public boolean notCheckHash = false;
     public int lastHash = -1;
 
-    private HashMap<Integer, Integer> mMenusMap = new HashMap<>();
-
     public PopMenu() {
         super();
     }
@@ -563,9 +561,8 @@ public class PopMenu extends BaseDialog {
                     if (!closing) {
                         lastHash = menuList.hashCode();
                         boolean callBack = getOnMenuItemClickListener().onClick(me, menuList.get(position), position);
-                        Integer hash = addMenuMap(0, menuList.hashCode());
-                        if (hash != null && !notCheckHash) {
-                            if (hash != lastHash) {
+                        if (!notCheckHash) {
+                            if (lastHash == menuList.hashCode()) {
                                 if (callBack) {
                                     callBack = false;
                                 }
@@ -578,10 +575,6 @@ public class PopMenu extends BaseDialog {
                 }
             });
             onDialogInit();
-        }
-
-        private Integer addMenuMap(int position, int hashCode) {
-            return mMenusMap.put(position, hashCode);
         }
 
         @Override
@@ -918,7 +911,6 @@ public class PopMenu extends BaseDialog {
                 if (dialogImpl == null) {
                     return;
                 }
-                mMenusMap.clear();
                 dialogImpl.doDismiss(null);
             }
         });

--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopMenu.java
@@ -92,6 +92,10 @@ public class PopMenu extends BaseDialog {
     // 记录 baseView 位置
     protected DialogXViewLoc baseViewLoc = new DialogXViewLoc();
     private int selectIndex;
+    public boolean notCheckHash = false;
+    public int lastHash = -1;
+
+    private HashMap<Integer, Integer> mMenusMap = new HashMap<>();
 
     public PopMenu() {
         super();
@@ -554,16 +558,30 @@ public class PopMenu extends BaseDialog {
             listMenu.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                 @Override
                 public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                    haptic(view);
                     selectIndex = position;
                     if (!closing) {
-                        if (!getOnMenuItemClickListener().onClick(me, menuList.get(position), position)) {
-                            haptic(view);
+                        lastHash = menuList.hashCode();
+                        boolean callBack = getOnMenuItemClickListener().onClick(me, menuList.get(position), position);
+                        Integer hash = addMenuMap(0, menuList.hashCode());
+                        if (hash != null && !notCheckHash) {
+                            if (hash != lastHash) {
+                                if (callBack) {
+                                    callBack = false;
+                                }
+                            }
+                        }
+                        if (!callBack) {
                             dismiss();
                         }
                     }
                 }
             });
             onDialogInit();
+        }
+
+        private Integer addMenuMap(int position, int hashCode) {
+            return mMenusMap.put(position, hashCode);
         }
 
         @Override
@@ -900,6 +918,7 @@ public class PopMenu extends BaseDialog {
                 if (dialogImpl == null) {
                     return;
                 }
+                mMenusMap.clear();
                 dialogImpl.doDismiss(null);
             }
         });

--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopNotification.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/PopNotification.java
@@ -8,8 +8,6 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
-import android.os.Handler;
-import android.os.Looper;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -652,6 +650,7 @@ public class PopNotification extends BaseDialog implements NoTouchInterface {
             boxBody.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    haptic(v);
                     if (onPopNotificationClickListener != null) {
                         if (!onPopNotificationClickListener.onClick(me, v)) {
                             dismiss();
@@ -665,6 +664,7 @@ public class PopNotification extends BaseDialog implements NoTouchInterface {
             txtDialogxButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    haptic(v);
                     if (onButtonClickListener != null) {
                         if (!onButtonClickListener.onClick(me, v)) {
                             doDismiss(v);
@@ -1456,6 +1456,11 @@ public class PopNotification extends BaseDialog implements NoTouchInterface {
     public PopNotification setRootPadding(int paddingLeft, int paddingTop, int paddingRight, int paddingBottom) {
         this.screenPaddings = new int[]{paddingLeft, paddingTop, paddingRight, paddingBottom};
         refreshUI();
+        return this;
+    }
+
+    public PopNotification setHapticFeedbackEnabled(boolean isHapticFeedbackEnabled) {
+        this.isHapticFeedbackEnabled = isHapticFeedbackEnabled ? 1 : 0;
         return this;
     }
 


### PR DESCRIPTION
![image](https://github.com/kongzue/DialogX/assets/123531821/2797c830-3391-4e07-ba86-75b1acd346eb)
因为 index 等于 0，时会打开延续打开弹窗，但是新弹窗的索引index也会等于0，这就导致点击“产品A”不能关闭弹窗。
更极端的情况text和上面有相同，也会导致不能关闭弹窗。
我的解决方法是比较List的Hash，实测可以正常。当然想要不比较Hash，只需要设置
dialog.notCheckHash = true;