### PR TITLE
Fix DialogListBuilder clear and add test

### DIFF
--- a/DialogX/build.gradle
+++ b/DialogX/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4+'
     compileOnly files('libs\\androidx-rs.jar')
     api files('libs\\DialogXInterface.jar')
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/DialogX/src/main/java/com/kongzue/dialogx/util/DialogListBuilder.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/util/DialogListBuilder.java
@@ -69,6 +69,8 @@ public class DialogListBuilder {
     }
 
     public void clear() {
-        dialogs.clear();
+        if (dialogs != null) {
+            dialogs.clear();
+        }
     }
 }

--- a/DialogX/src/test/java/com/kongzue/dialogx/util/DialogListBuilderTest.java
+++ b/DialogX/src/test/java/com/kongzue/dialogx/util/DialogListBuilderTest.java
@@ -1,0 +1,11 @@
+import com.kongzue.dialogx.util.DialogListBuilder;
+import org.junit.Test;
+
+public class DialogListBuilderTest {
+
+    @Test
+    public void clearOnNewBuilderShouldNotThrow() {
+        DialogListBuilder builder = DialogListBuilder.create();
+        builder.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- check for null before clearing dialogs
- add simple unit test for clear()
- include junit in DialogX library for tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f54bfb1483278178cc423a66d0ca