### PR TITLE
Fix NullPointerException in DialogFragmentImpl.onStart

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/impl/DialogFragmentImpl.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/impl/DialogFragmentImpl.java
@@ -60,6 +60,7 @@ public class DialogFragmentImpl extends DialogFragment {
     @Override
     public void onStart() {
         super.onStart();
+        if (activityWeakReference == null) return;
         final Activity activity = activityWeakReference.get();
 
         if (getDialog() == null) return;


### PR DESCRIPTION
## Summary
Add null check for `activityWeakReference` in `onStart()` to prevent NullPointerException when the weak reference has been cleared.

## Details
The `activityWeakReference` can become null during the fragment lifecycle, particularly if the activity is destroyed before the dialog fragment's `onStart()` is called. Attempting to call `.get()` on a null reference causes an NPE. This fix adds an early return if the weak reference is null, allowing the dialog to handle the lifecycle gracefully.

## Testing
Verified that the dialog no longer crashes when `onStart()` is called after the activity reference has been cleared.

Fixes #530