### PR TITLE
fix: 修复单选模式下调用syncMultiSelectResult闪退的问题

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/dialogs/MessageMenu.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/dialogs/MessageMenu.java
@@ -487,6 +487,11 @@ public class MessageMenu extends MessageDialog {
     private CharSequence[] selectTextArray;
 
     private void syncMultiSelectResult() {
+        if (selectionItems == null) {
+            resultArray = null;
+            selectTextArray = null;
+            return;
+        }
         resultArray = new int[selectionItems.size()];
         selectTextArray = new CharSequence[selectionItems.size()];
         for (int i = 0; i < selectionItems.size(); i++) {


### PR DESCRIPTION
让最新行为与之前行为同步，在单选模式下调用getSelectionIndexArray或getSelectTextArray时，返回null而不是空指针崩溃