### PR TITLE
Fix ClassCastException in DialogXBaseRelativeLayout caused by ContextThemeWrapper

### DIFF
--- a/DialogX/src/main/java/com/kongzue/dialogx/util/views/DialogXBaseRelativeLayout.java
+++ b/DialogX/src/main/java/com/kongzue/dialogx/util/views/DialogXBaseRelativeLayout.java
@@ -22,7 +22,6 @@ import androidx.activity.ViewTreeOnBackPressedDispatcherOwner;
 import androidx.annotation.Px;
 import androidx.core.graphics.Insets;
 import androidx.core.view.WindowInsetsCompat;
-import androidx.lifecycle.LifecycleOwner;
 
 import com.kongzue.dialogx.DialogX;
 import com.kongzue.dialogx.R;
@@ -278,7 +277,7 @@ public class DialogXBaseRelativeLayout extends RelativeLayout {
         if (bind) {
             OnBackPressedDispatcherOwner owner = ViewTreeOnBackPressedDispatcherOwner.get(this);
             if (owner == null) return;
-            owner.getOnBackPressedDispatcher().addCallback((LifecycleOwner) getContext(),
+            owner.getOnBackPressedDispatcher().addCallback(owner,
                     onBackPressedCallback= new OnBackPressedCallback(true) {
                         @Override
                         public void handleOnBackPressed() {


### PR DESCRIPTION
## Fix ClassCastException in DialogXBaseRelativeLayout caused by ContextThemeWrapper

### 崩溃堆栈 (Crash Log)
```text
java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to androidx.lifecycle.LifecycleOwner
    at com.kongzue.dialogx.util.views.DialogXBaseRelativeLayout.setBackPressedDispatcher(DialogXBaseRelativeLayout.java:281)

```

### 复现配置

* **环境配置**：升级 `androidx.activity:activity` 至 **1.8.0**，`androidx.appcompat:appcompat` 至 **1.7.1**。
* **样式触发**：设置 `DialogX.globalStyle = MaterialYouStyle.style()` 或在布局 XML 中对 `DialogXBaseRelativeLayout` 声明 `android:theme`。
* **操作**：显示任意使用了 `DialogXBaseRelativeLayout` 的弹窗（如 `BottomMenu` 或 `PopMenu`）。

### 原因分析

#### 1. 低版本依赖环境

* **依赖状态**：使用 `appcompat:1.3.0` 等早期版本。
* **具体表现**：`AppCompatActivity`在执行 **`initViewTreeOwners`** 时，仅进行了 `Lifecycle`、`ViewModel` 等 Owners 注入，**不会注入** `OnBackPressedDispatcherOwner`。
* **结果**：`ViewTreeOnBackPressedDispatcherOwner.get(this)` 始终返回 `null`。由于代码中存在 `if (owner == null) return;` 保护逻辑，后续强转代码被跳过，Bug 未被触发。

#### 2. 高版本依赖环境

* **依赖状态**：升级至 `activity:1.8.0` / `appcompat:1.7.1` 等新版本。
* **具体表现**：`AppCompatActivity`在执行 **`initViewTreeOwners`** 时会同步注入 `OnBackPressedDispatcherOwner`。此时 `owner` 获取成功，逻辑向下运行。
* **崩溃原因**：由于 `MaterialYouStyle` 或布局中声明了 `android:theme`，`getContext()` 会返回 `ContextThemeWrapper`。该包装类未实现 `LifecycleOwner` 接口，执行强转 `(LifecycleOwner) getContext()` 时崩溃。

### 修复方案

**直接利用获取到的 `owner` 对象进行回调注册。**
根据 AndroidX 源码，`OnBackPressedDispatcherOwner` 接口已继承 `LifecycleOwner`。直接使用 `owner` 传入 `addCallback` 即可避开对 `getContext()` 的非法强转。

```java
// 修复后
owner.getOnBackPressedDispatcher().addCallback(owner, onBackPressedCallback);

```